### PR TITLE
feat: pulumi-stack skill + Pulumi references in existing skills (#1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,1 +1,1 @@
-{"name":"@gonzih/skills-devops","version":"1.0.0","description":"DevOps skills for Claude Code","type":"module","scripts":{"postinstall":"node install.js"},"files":["skills/","install.js","README.md"],"keywords":["claude","mcp","skills","devops"],"license":"MIT"}
+{"name":"@gonzih/skills-devops","version":"1.1.0","description":"DevOps skills for Claude Code","type":"module","scripts":{"postinstall":"node install.js"},"files":["skills/","install.js","README.md"],"keywords":["claude","mcp","skills","devops"],"license":"MIT"}

--- a/skills/ci-cd-troubleshooter/SKILL.md
+++ b/skills/ci-cd-troubleshooter/SKILL.md
@@ -20,6 +20,15 @@ Diagnose failing CI/CD pipelines, identify root causes, and propose or apply fix
 4. Propose a fix and explain the root cause
 5. Offer to apply the fix to the config file
 
+## Pulumi CI patterns (GitHub Actions)
+When the pipeline deploys infrastructure with Pulumi, check for:
+- Action: `pulumi/actions@v5` — required for `pulumi preview` and `pulumi up` steps
+- Required env var: `PULUMI_ACCESS_TOKEN` (must be stored as a repository secret)
+- Common failures:
+  - **Stack lock**: another run holds the state lock — cancel or use `pulumi cancel`
+  - **Config missing**: stack config not committed or secret not set — run `pulumi config set <key>`
+  - **Passphrase prompt**: `PULUMI_CONFIG_PASSPHRASE` env var missing for self-managed backends
+
 ## Example
 User: "My GitHub Actions deploy job is failing with 'Error: Unable to locate executable file: docker'"
 → Diagnose missing Docker setup step, suggest `docker/setup-buildx-action`, apply to workflow YAML.

--- a/skills/incident-commander/SKILL.md
+++ b/skills/incident-commander/SKILL.md
@@ -21,6 +21,12 @@ Guide incident response from detection through resolution, coordinate communicat
 5. **Resolve**: Confirm resolution criteria met; set follow-up review time
 6. **Postmortem**: Generate blameless postmortem doc with 5-whys root cause analysis and action items
 
+## Infra rollback (Pulumi)
+When the incident involves infrastructure managed by Pulumi:
+1. Run `pulumi stack history` to list recent deployments and identify the last known-good deploy
+2. Re-deploy the previous version: check out the corresponding commit and run `pulumi up`, or use `pulumi up --target-replace <urn>` for surgical replacement of a single resource
+3. Use `pulumi refresh` after rollback to confirm state matches real infrastructure
+
 ## Example
 User: "Production database is down, started 14:32 UTC, ~10k users affected"
 → Declares SEV1, drafts initial stakeholder update, starts timeline, prompts for on-call contacts, and guides through mitigation steps to resolution and postmortem.

--- a/skills/pulumi-stack/SKILL.md
+++ b/skills/pulumi-stack/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: pulumi-stack
+description: Scaffold, manage, and deploy infrastructure as code using Pulumi (TypeScript-first).
+triggers: ["pulumi", "infrastructure as code", "iac", "deploy infrastructure", "pulumi stack"]
+---
+# Pulumi Stack
+
+## What this skill does
+Helps you scaffold new Pulumi stacks, convert from Terraform, write programs for common cloud patterns, and manage the full deploy lifecycle using real TypeScript/Python/Go — not DSLs.
+
+## How to invoke
+/pulumi-stack
+
+## Workflow steps
+
+### Step 1 — Choose stack type
+Identify cloud target (AWS/GCP/Azure/K8s) and language preference (default: TypeScript).
+
+### Step 2 — Scaffold or convert
+New stack: `pulumi new aws-typescript` (or relevant template)
+From Terraform: `pulumi convert --from terraform --language typescript`
+
+### Step 3 — Write the program
+Common patterns:
+- VPC + subnets: use `@pulumi/awsx` NetworkX components
+- ECS/EKS cluster: `awsx.ecs.Cluster` or `aws.eks.Cluster`
+- RDS: `aws.rds.Instance` with `skipFinalSnapshot: false`
+- S3 + CloudFront CDN: `aws.s3.Bucket` + `aws.cloudfront.Distribution`
+- Secrets: `pulumi config set --secret DATABASE_PASSWORD`
+
+### Step 4 — Preview and deploy
+```bash
+pulumi preview   # dry run, shows what will change
+pulumi up        # apply changes
+pulumi stack history  # audit trail
+```
+
+### Step 5 — Drift detection
+```bash
+pulumi refresh   # sync state with real infra
+```
+
+## Example outputs
+- Scaffolded TypeScript Pulumi program for AWS VPC + ECS
+- Converted Terraform module to Pulumi TypeScript
+- Deploy preview showing resource changes

--- a/skills/runbook-writer/SKILL.md
+++ b/skills/runbook-writer/SKILL.md
@@ -20,6 +20,12 @@ Generate clear, actionable operational runbooks for services, infrastructure com
 4. Review for completeness: every step has a verification command, rollback is covered
 5. Save to the appropriate location (e.g., `docs/runbooks/<service>.md`)
 
+## Infra change runbooks (Pulumi)
+When the runbook covers an infrastructure change managed by Pulumi, include:
+- `pulumi preview` output showing the planned resource changes (paste or link)
+- Link to the stack in Pulumi Cloud (e.g. `https://app.pulumi.com/<org>/<project>/<stack>`)
+- Rollback step using `pulumi stack history` to identify the previous deployment and re-run it
+
 ## Example
 User: "Write a runbook for restarting the payment-service in Kubernetes"
 → Produces a runbook covering health checks, drain, rolling restart, verification, and rollback with `kubectl` commands.


### PR DESCRIPTION
## Summary
- Adds `pulumi-stack` skill covering scaffold, convert from Terraform, deploy lifecycle, and drift detection
- Updates `runbook-writer` to include `pulumi preview` output and Pulumi Cloud stack link in infra runbooks
- Updates `ci-cd-troubleshooter` with Pulumi GitHub Actions patterns (`pulumi/actions@v5`, `PULUMI_ACCESS_TOKEN`, common failures)
- Updates `incident-commander` with infra rollback section using `pulumi stack history` and `pulumi up --target-replace`
- Bumps package version to `1.1.0`

## Test plan
- [ ] Verify `skills/pulumi-stack/SKILL.md` exists with correct frontmatter and all 5 workflow steps
- [ ] Verify `runbook-writer/SKILL.md` includes Pulumi infra change section
- [ ] Verify `ci-cd-troubleshooter/SKILL.md` includes Pulumi CI patterns section
- [ ] Verify `incident-commander/SKILL.md` includes Pulumi rollback section
- [ ] Verify `package.json` version is `1.1.0`

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)